### PR TITLE
[Update] Add CorrelationId property

### DIFF
--- a/src/FunctionApp/Functions/GetUsersQueue.cs
+++ b/src/FunctionApp/Functions/GetUsersQueue.cs
@@ -69,7 +69,7 @@ public class GetUsersQueue
         UserPasswordExpirationDetails[] foundUsersEnriched = new UserPasswordExpirationDetails[foundUsers.Length];
         for (int i = 0; i < foundUsers.Length; i++)
         {
-            foundUsersEnriched[i] = new(foundUsers[i], searchConfig);
+            foundUsersEnriched[i] = new(foundUsers[i], searchConfig, queueItem.CorrelationId);
         }
 
         // Get the users with expiring passwords.

--- a/src/FunctionApp/Functions/GetUsersQueue.cs
+++ b/src/FunctionApp/Functions/GetUsersQueue.cs
@@ -47,7 +47,7 @@ public class GetUsersQueue
         // Get the user search config.
         UserSearchConfig searchConfig = await _cosmosDbClientService.GetUserSearchConfigAsync(queueItem.UserSearchConfigId);
 
-        logger.LogInformation("Received request to get users with last name starting with {lastNameStartsWith} from {domainName}.", queueItem.LastNameStartsWith.ToUpper(), queueItem.DomainName);
+        logger.LogInformation("Received request to get users with last name starting with {lastNameStartsWith} from {domainName}. [CorrelationId: {CorrelationId}]",queueItem.LastNameStartsWith.ToUpper(), queueItem.DomainName, queueItem.CorrelationId);
 
         // Get the users from the Graph API.
         logger.LogInformation("Getting users from Graph API...");
@@ -60,7 +60,7 @@ public class GetUsersQueue
         if (foundUsers is null || foundUsers.Length == 0)
         {
             stopwatch.Stop();
-            logger.LogInformation("[{LastNameStartsWith} - {DomainName}] Found no users in {Minutes}:{Seconds}.{Milliseconds}.", queueItem.LastNameStartsWith, queueItem.DomainName, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds, stopwatch.Elapsed.Milliseconds);
+            logger.LogInformation("[{LastNameStartsWith} - {DomainName}] Found no users in {Minutes}:{Seconds}.{Milliseconds}. [CorrelationId: {CorrelationId}]", queueItem.LastNameStartsWith, queueItem.DomainName, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds, stopwatch.Elapsed.Milliseconds, queueItem.CorrelationId);
 
             return;
         }
@@ -89,6 +89,6 @@ public class GetUsersQueue
         }
 
         stopwatch.Stop();
-        logger.LogInformation("[{LastNameStartsWith} - {DomainName}] Found {foundUsersCount} users in {Minutes}:{Seconds}.{Milliseconds}.", queueItem.LastNameStartsWith, queueItem.DomainName, usersWithExpiringPasswords.Length, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds, stopwatch.Elapsed.Milliseconds);
+        logger.LogInformation("[{LastNameStartsWith} - {DomainName}] Found {foundUsersCount} users in {Minutes}:{Seconds}.{Milliseconds}. [CorrelationId: {CorrelationId}]", queueItem.LastNameStartsWith, queueItem.DomainName, usersWithExpiringPasswords.Length, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds, stopwatch.Elapsed.Milliseconds, queueItem.CorrelationId);
     }
 }

--- a/src/FunctionApp/Functions/QueueUpUserSearch.cs
+++ b/src/FunctionApp/Functions/QueueUpUserSearch.cs
@@ -62,7 +62,8 @@ public class QueueUpUserSearch
                             MaxPasswordAge = configItem.MaxPasswordAge,
                             IsEmailIntervalsEnabled = configItem.IsEmailIntervalsEnabled,
                             EmailIntervalDays = configItem.EmailIntervalDays,
-                            EmailTemplateId = configItem.EmailTemplateId!
+                            EmailTemplateId = configItem.EmailTemplateId!,
+                            CorrelationId = Guid.NewGuid().ToString()
                         },
                         jsonTypeInfo: _jsonSourceGenerationContext.UserSearchQueueItem
                     )

--- a/src/Lib/Models/ManualSendEmailItem.cs
+++ b/src/Lib/Models/ManualSendEmailItem.cs
@@ -14,4 +14,8 @@ public class ManualSendEmailItem : IManualSendEmailItem
     /// <inheritdoc />
     [JsonPropertyName("userSearchConfigId")]
     public string? UserSearchConfigId { get; set; }
+
+    /// <inheritdoc />
+    [JsonPropertyName("correlationId")]
+    public string CorrelationId { get; set; } = null!;
 }

--- a/src/Lib/Models/UserPasswordExpirationDetails.cs
+++ b/src/Lib/Models/UserPasswordExpirationDetails.cs
@@ -20,6 +20,7 @@ public class UserPasswordExpirationDetails : IUserPasswordExpirationDetails
         UserSearchConfigId = searchConfig.Id;
         PasswordLastSetDate = user.LastPasswordChangeDateTime is not null ? user.LastPasswordChangeDateTime.Value.UtcDateTime : DateTimeOffset.MinValue;
         MaxPasswordAge = searchConfig.MaxPasswordAge;
+        CorrelationId = Guid.NewGuid().ToString();
     }
 
     public UserPasswordExpirationDetails(User user, UserSearchConfig searchConfig, string correlationId)

--- a/src/Lib/Models/UserPasswordExpirationDetails.cs
+++ b/src/Lib/Models/UserPasswordExpirationDetails.cs
@@ -22,6 +22,16 @@ public class UserPasswordExpirationDetails : IUserPasswordExpirationDetails
         MaxPasswordAge = searchConfig.MaxPasswordAge;
     }
 
+    public UserPasswordExpirationDetails(User user, UserSearchConfig searchConfig, string correlationId)
+    {
+        Id = user.Id;
+        User = user;
+        UserSearchConfigId = searchConfig.Id;
+        PasswordLastSetDate = user.LastPasswordChangeDateTime is not null ? user.LastPasswordChangeDateTime.Value.UtcDateTime : DateTimeOffset.MinValue;
+        MaxPasswordAge = searchConfig.MaxPasswordAge;
+        CorrelationId = correlationId;
+    }
+
     /// <inheritdoc />
     [JsonPropertyName("id")]
     public string Id { get; set; } = null!;
@@ -61,4 +71,8 @@ public class UserPasswordExpirationDetails : IUserPasswordExpirationDetails
     /// <inheritdoc />
     [JsonPropertyName("passwordIsExpiringSoon")]
     public bool PasswordIsExpiringSoon => PasswordExpiresIn.Days <= TimeSpan.FromDays(10).Days;
+
+    /// <inheritdoc />
+    [JsonPropertyName("correlationId")]
+    public string CorrelationId { get; set; } = null!;
 }

--- a/src/Lib/Models/UserSearchQueueItem.cs
+++ b/src/Lib/Models/UserSearchQueueItem.cs
@@ -39,4 +39,8 @@ public class UserSearchQueueItem : IUserSearchQueueItem
     /// <inheritdoc />
     [JsonPropertyName("emailTemplateId")]
     public string EmailTemplateId { get; set; } = null!;
+
+    /// <inheritdoc />
+    [JsonPropertyName("correlationId")]
+    public string CorrelationId { get; set; } = null!;
 }

--- a/src/Lib/Models/interfaces/IManualSendEmailItem.cs
+++ b/src/Lib/Models/interfaces/IManualSendEmailItem.cs
@@ -14,4 +14,9 @@ public interface IManualSendEmailItem
     /// The unique ID of the <see cref="Config.UserSearchConfig"/> to use for the email.
     /// </summary>
     string? UserSearchConfigId { get; set; }
+
+    /// <summary>
+    /// A unique ID to correlate the user search with the email sending.
+    /// </summary>
+    string CorrelationId { get; set; }
 }

--- a/src/Lib/Models/interfaces/IUserPasswordExpirationDetails.cs
+++ b/src/Lib/Models/interfaces/IUserPasswordExpirationDetails.cs
@@ -56,4 +56,9 @@ public interface IUserPasswordExpirationDetails
     /// Whether the user's password is expiring soon or not.
     /// </summary>
     bool PasswordIsExpiringSoon { get; }
+
+    /// <summary>
+    /// A unique ID to correlate the user search with the email sending.
+    /// </summary>
+    string CorrelationId { get; set; }
 }

--- a/src/Lib/Models/interfaces/IUserSearchQueueItem.cs
+++ b/src/Lib/Models/interfaces/IUserSearchQueueItem.cs
@@ -46,4 +46,9 @@ public interface IUserSearchQueueItem
     /// The ID of the email template to use.
     /// </summary>
     string EmailTemplateId { get; set; }
+
+    /// <summary>
+    /// A unique ID to correlate the user search with the email sending.
+    /// </summary>
+    string CorrelationId { get; set; }
 }


### PR DESCRIPTION
Adds a `CorrelationId` property to the `UserSearchQueueItem` and `UserPasswordExpirationDetails` classes to help track job executions from their initial source.