### PR TITLE
[Bug fix] Email draft pollution

### DIFF
--- a/src/FunctionApp/Functions/SendEmail.cs
+++ b/src/FunctionApp/Functions/SendEmail.cs
@@ -88,21 +88,18 @@ public class SendEmail
         string toRecipient = redirectConfig is null ? queueItem.User.UserPrincipalName : redirectConfig.RedirectUserPrincipalName!;
 
         // Create the email message.
-        MailMessage emailMessage = new(
-            message: new(
-                subject: $"Alert: Password Expiration Notice ({Math.Round(queueItem.PasswordExpiresIn.TotalDays, 0)} days)",
-                body: new(emailBody, "HTML"),
-                toRecipient: new Recipient[]
-                {
-                    new(toRecipient, null)
-                },
-                attachments: fileAttachments
-            )
+        Message emailMessage = new(
+            subject: $"Alert: Password Expiration Notice ({Math.Round(queueItem.PasswordExpiresIn.TotalDays, 0)} days)",
+            body: new(emailBody, "HTML"),
+            toRecipient: new Recipient[]
             {
-                CcRecipient = new Recipient[] { }
+                new(toRecipient, null)
             },
-            saveToSentItems: false
-        );
+            attachments: fileAttachments
+        )
+        {
+            CcRecipient = new Recipient[] { }
+        };
 
         if (!userSearchConfigItem.DoNotSendEmails)
         {

--- a/src/Lib/Models/Graph/Message.cs
+++ b/src/Lib/Models/Graph/Message.cs
@@ -30,6 +30,9 @@ public class Message : IMessage
         }
     }
 
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
     /// <inheritdoc />
     [JsonPropertyName("subject")]
     public string Subject { get; set; } = null!;

--- a/src/Lib/Models/Graph/interfaces/IMessage.cs
+++ b/src/Lib/Models/Graph/interfaces/IMessage.cs
@@ -6,6 +6,11 @@
 public interface IMessage
 {
     /// <summary>
+    /// The unique identifier for the message.
+    /// </summary>
+    string? Id { get; set; }
+
+    /// <summary>
     /// The subject of the message.
     /// </summary>
     string Subject { get; set; }

--- a/src/Lib/Services/GraphClientService/GraphClientService.SendEmailAsync.cs
+++ b/src/Lib/Services/GraphClientService/GraphClientService.SendEmailAsync.cs
@@ -6,22 +6,42 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 public partial class GraphClientService
 {
     /// <inheritdoc />
-    public async Task SendEmailAsync(MailMessage message, string sendAsUser)
+    public async Task SendEmailAsync(Message message, string sendAsUser)
     {
         // Serialize the message to JSON.
         string messageJson = JsonSerializer.Serialize(
             value: message,
-            jsonTypeInfo: _jsonSourceGenerationContext.MailMessage
+            jsonTypeInfo: _jsonSourceGenerationContext.Message
         );
 
         try
         {
-            // Send the email.
-            await _graphClient.SendApiCallAsync(
-                endpoint: $"users/{sendAsUser}/sendMail",
+            // Create a draft message.
+            string? draftResponse = await _graphClient.SendApiCallAsync(
+                endpoint: $"users/{sendAsUser}/messages",
                 apiPostBody: messageJson,
                 httpMethod: HttpMethod.Post
             );
+
+            Message draftItem = JsonSerializer.Deserialize(
+                json: draftResponse!,
+                jsonTypeInfo: _jsonSourceGenerationContext.Message
+            )!;
+
+            // Send the draft message.
+            await _graphClient.SendApiCallAsync(
+                endpoint: $"users/{sendAsUser}/messages/{draftItem.Id!}/send",
+                apiPostBody: null,
+                httpMethod: HttpMethod.Post
+            );
+
+            // Delete the draft message.
+            await _graphClient.SendApiCallAsync(
+                endpoint: $"users/{sendAsUser}/messages/{draftItem.Id!}",
+                apiPostBody: null,
+                httpMethod: HttpMethod.Delete
+            );
+
         }
         catch (Exception ex)
         {

--- a/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
+++ b/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
@@ -37,5 +37,5 @@ public interface IGraphClientService
     /// <param name="message">The message to send.</param>
     /// <param name="sendAsUser">The user principal name of the user to send the email as.</param>
     /// <exception cref="Exception"></exception>
-    Task SendEmailAsync(MailMessage message, string sendAsUser);
+    Task SendEmailAsync(Message message, string sendAsUser);
 }


### PR DESCRIPTION
This _should_ fix an issue where the emails would pollute the drafts folder of the **send-as user**.

What happens now is:

1. A draft is created in the **send-as user's** mailbox.
2. The draft is sent.
3. The draft is immediately deleted from the mailbox.