### PR TITLE
[Update] Remove SmallsOnline.MsGraphClient dependency

### DIFF
--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
+using SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
 using SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -45,9 +46,19 @@ builder.Services
 builder.Services
     .AddSingleton<IGraphClientService, GraphClientService>(
         provider => new(
-            clientId: builder.Configuration.GetSection("backendClientID").Value!,
-            clientSecret: builder.Configuration.GetSection("backendClientSecret").Value!,
-            tenantId: builder.Configuration.GetSection("backendTenantId").Value!
+            config: new()
+            {
+                ClientId = builder.Configuration.GetSection("backendClientId").Value!,
+                TenantId = builder.Configuration.GetSection("backendTenantId").Value!,
+                Credential = new GraphClientCredential(
+                    credentialType: GraphClientCredentialType.ClientSecret,
+                    clientSecret: builder.Configuration.GetSection("backendClientSecret").Value!
+                ),
+                ApiScopes = new[]
+                {
+                    "https://graph.microsoft.com/.default"
+                }
+            }
         )
     );
 

--- a/src/AdminConsole/Shared/UserSearchConfigs/UserSearchConfigForm.razor
+++ b/src/AdminConsole/Shared/UserSearchConfigs/UserSearchConfigForm.razor
@@ -205,6 +205,16 @@
                     </div>
                 </div>
             }
+            else if (_users is null)
+            {
+                <div class="row">
+                    <div class="col">
+                        <p>
+                            Click the button above to get users.
+                        </p>
+                    </div>
+                </div>
+            }
             else
             {
                 <div class="row">

--- a/src/FunctionApp/Program.cs
+++ b/src/FunctionApp/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SmallsOnline.PasswordExpirationNotifier.FunctionApp;
 using SmallsOnline.PasswordExpirationNotifier.FunctionApp.Services;
+using SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
 using SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 IHostBuilder hostBuilder = new HostBuilder()
@@ -20,9 +21,19 @@ IHostBuilder hostBuilder = new HostBuilder()
         {
             services.AddSingleton<IGraphClientService, GraphClientService>(
                 provider => new GraphClientService(
-                    clientId: AppSettingsHelper.GetSettingValue("clientId")!,
-                    clientSecret: AppSettingsHelper.GetSettingValue("clientSecret")!,
-                    tenantId: AppSettingsHelper.GetSettingValue("tenantId")!
+                    config: new()
+                    {
+                        ClientId = AppSettingsHelper.GetSettingValue("clientId")!,
+                        TenantId = AppSettingsHelper.GetSettingValue("tenantId")!,
+                        Credential = new GraphClientCredential(
+                            credentialType: GraphClientCredentialType.ClientSecret,
+                            clientSecret: AppSettingsHelper.GetSettingValue("clientSecret")!
+                        ),
+                        ApiScopes = new[]
+                        {
+                            "https://graph.microsoft.com/.default"
+                        }
+                    }
                 )
             );
 

--- a/src/Lib/Lib.csproj
+++ b/src/Lib/Lib.csproj
@@ -24,9 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SmallsOnline.MsGraphClient" Version="2022.8.0-beta04">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Lib/Models/Graph/GraphClientConfig.cs
+++ b/src/Lib/Models/Graph/GraphClientConfig.cs
@@ -1,0 +1,19 @@
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+/// <summary>
+/// Holds the configuration for the Microsoft Graph API client used in <see cref="SmallsOnline.PasswordExpirationNotifier.Lib.Services.GraphClientService" />.
+/// </summary>
+public class GraphClientConfig : IGraphClientConfig
+{
+    /// <inheritdoc />
+    public string ClientId { get; set; } = null!;
+
+    /// <inheritdoc />
+    public string TenantId { get; set; } = null!;
+
+    /// <inheritdoc />
+    public string[] ApiScopes { get; set; } = null!;
+
+    /// <inheritdoc />
+    public IGraphClientCredential Credential { get; set; } = null!;
+}

--- a/src/Lib/Models/Graph/GraphClientCredential.cs
+++ b/src/Lib/Models/Graph/GraphClientCredential.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+/// <summary>
+/// Holds the credentials for authenticating with the Microsoft Graph API.
+/// </summary>
+public class GraphClientCredential : IGraphClientCredential
+{
+    public GraphClientCredential(GraphClientCredentialType credentialType, string clientSecret)
+    {
+        CredentialType = credentialType;
+        ClientSecret = clientSecret;
+    }
+
+    public GraphClientCredential(GraphClientCredentialType credentialType, X509Certificate2 clientCertificate)
+    {
+        CredentialType = credentialType;
+        ClientCertificate = clientCertificate;
+    }
+
+    /// <inheritdoc />
+    public GraphClientCredentialType CredentialType { get; }
+
+    /// <inheritdoc />
+    public string? ClientSecret { get; }
+
+    /// <inheritdoc />
+    public X509Certificate2? ClientCertificate { get; }
+}

--- a/src/Lib/Models/Graph/GraphClientCredentialType.cs
+++ b/src/Lib/Models/Graph/GraphClientCredentialType.cs
@@ -1,0 +1,17 @@
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+/// <summary>
+/// The type of credential to use for authenticating an Azure AD app with the Microsoft Graph API.
+/// </summary>
+public enum GraphClientCredentialType
+{
+    /// <summary>
+    /// The app uses a client secret for authentication.
+    /// </summary>
+    ClientSecret,
+
+    /// <summary>
+    /// The app uses a certificate for authentication.
+    /// </summary>
+    ClientCertificate
+}

--- a/src/Lib/Models/Graph/interfaces/IGraphClientConfig.cs
+++ b/src/Lib/Models/Graph/interfaces/IGraphClientConfig.cs
@@ -1,0 +1,27 @@
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+/// <summary>
+/// Interface for configuring the Microsoft Graph client in <see cref="SmallsOnline.PasswordExpirationNotifier.Lib.Services.GraphClientService"/>.
+/// </summary>
+public interface IGraphClientConfig
+{
+    /// <summary>
+    /// The client ID of the Azure AD app.
+    /// </summary>
+    string ClientId { get; set; }
+    
+    /// <summary>
+    /// The tenant ID of the Azure AD app.
+    /// </summary>
+    string TenantId { get; set; }
+    
+    /// <summary>
+    /// The API scopes to request.
+    /// </summary>
+    string[] ApiScopes { get; set; }
+
+    /// <summary>
+    /// The credential to use for authenticating with the Microsoft Graph API.
+    /// </summary>
+    IGraphClientCredential Credential { get; set; }
+}

--- a/src/Lib/Models/Graph/interfaces/IGraphClientCredential.cs
+++ b/src/Lib/Models/Graph/interfaces/IGraphClientCredential.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+/// <summary>
+/// Interface for holding credentials for authenticating with the Microsoft Graph API.
+/// </summary>
+public interface IGraphClientCredential
+{
+    /// <summary>
+    /// The type of the credential.
+    /// </summary>
+    GraphClientCredentialType CredentialType { get; }
+
+    /// <summary>
+    /// The client secret for the app.
+    /// </summary>
+    string? ClientSecret { get; }
+
+    /// <summary>
+    /// The certificate for the app.
+    /// </summary>
+    X509Certificate2? ClientCertificate { get; }
+}

--- a/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
@@ -2,10 +2,16 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 public partial class GraphClientService
 {
+    /// <summary>
+    /// Connects to the Graph API and/or refreshes the authentication token if necessary.
+    /// </summary>
     private async Task ConnectAsync()
     {
+        // Invert the current value of _isConnected to determine if we need to connect.
         bool needsToConnect = !_isConnected;
 
+        // If we already have an authentication token, check if it's expired.
+        // If it is, we need to set the value for 'needsToConnect' to true to get a new token.
         if (_authToken is not null)
         {
             if (DateTimeOffset.Now >= _authToken.ExpiresOn)
@@ -14,6 +20,8 @@ public partial class GraphClientService
             }
         }
 
+        // If needed, get a new authentication token to connect
+        // to the Graph API.
         if (needsToConnect)
         {
             _authToken = await GetAuthTokenAsync();

--- a/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
@@ -1,0 +1,22 @@
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
+
+public partial class GraphClientService
+{
+    public async Task ConnectAsync()
+    {
+        bool needsToConnect = !_isConnected;
+
+        if (_authToken is not null)
+        {
+            if (DateTimeOffset.Now >= _authToken.ExpiresOn)
+            {
+                needsToConnect = true;
+            }
+        }
+
+        if (needsToConnect)
+        {
+            _authToken = await GetAuthTokenAsync();
+        }
+    }
+}

--- a/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/ConnectAsync.cs
@@ -2,7 +2,7 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 public partial class GraphClientService
 {
-    public async Task ConnectAsync()
+    private async Task ConnectAsync()
     {
         bool needsToConnect = !_isConnected;
 

--- a/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
@@ -1,0 +1,16 @@
+using Microsoft.Identity.Client;
+using SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
+
+public partial class GraphClientService
+{
+    public async Task<AuthenticationResult> GetAuthTokenAsync()
+    {
+        AuthenticationResult? authToken = await _confidentialClientApplication
+            .AcquireTokenForClient(_apiScopes)
+            .ExecuteAsync();
+
+        return authToken;
+    }
+}

--- a/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
@@ -5,6 +5,10 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 public partial class GraphClientService
 {
+    /// <summary>
+    /// Get an authentication token to connect to the Graph API.
+    /// </summary>
+    /// <returns><see cref="AuthenticationResult" /></returns>
     private async Task<AuthenticationResult> GetAuthTokenAsync()
     {
         AuthenticationResult? authToken = await _confidentialClientApplication

--- a/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
+++ b/src/Lib/Services/GraphClientService/authentication/GetAuthTokenAsync.cs
@@ -5,7 +5,7 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 public partial class GraphClientService
 {
-    public async Task<AuthenticationResult> GetAuthTokenAsync()
+    private async Task<AuthenticationResult> GetAuthTokenAsync()
     {
         AuthenticationResult? authToken = await _confidentialClientApplication
             .AcquireTokenForClient(_apiScopes)

--- a/src/Lib/Services/GraphClientService/general/SendApiCallAsync.cs
+++ b/src/Lib/Services/GraphClientService/general/SendApiCallAsync.cs
@@ -6,7 +6,13 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
 public partial class GraphClientService
 {
-    private async Task<string?> SendApiCallAsync(string endpoint, HttpMethod httpMethod) => await SendApiCallAsync(endpoint, httpMethod, null);
+    /// <summary>
+    /// Send an API call to the Graph API.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to call.</param>
+    /// <param name="httpMethod">The HTTP method to use.</param>
+    /// <param name="body">Contents to use in the body of the API call.</param>
+    /// <returns>If any, the response from the Graph API in string form.</returns>
     private async Task<string?> SendApiCallAsync(string endpoint, HttpMethod httpMethod, string? body)
     {
         await ConnectAsync();
@@ -56,4 +62,12 @@ public partial class GraphClientService
 
         return content;
     }
+
+    /// <summary>
+    /// Send an API call to the Graph API.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to call.</param>
+    /// <param name="httpMethod">The HTTP method to use.</param>
+    /// <returns>If any, the response from the Graph API in string form.</returns>
+    private async Task<string?> SendApiCallAsync(string endpoint, HttpMethod httpMethod) => await SendApiCallAsync(endpoint, httpMethod, null);
 }

--- a/src/Lib/Services/GraphClientService/general/SendApiCallAsync.cs
+++ b/src/Lib/Services/GraphClientService/general/SendApiCallAsync.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
+
+public partial class GraphClientService
+{
+    private async Task<string?> SendApiCallAsync(string endpoint, HttpMethod httpMethod) => await SendApiCallAsync(endpoint, httpMethod, null);
+    private async Task<string?> SendApiCallAsync(string endpoint, HttpMethod httpMethod, string? body)
+    {
+        await ConnectAsync();
+
+        string? content = null;
+        bool isFinished = false;
+
+        while (!isFinished)
+        {
+            using HttpRequestMessage request = new(
+                method: httpMethod,
+                requestUri: endpoint
+            );
+
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                scheme: "Bearer",
+                parameter: _authToken!.AccessToken
+            );
+
+            if (body is not null)
+            {
+                request.Content = new StringContent(
+                    content: body,
+                    encoding: Encoding.UTF8,
+                    mediaType: "application/json"
+                );
+            }
+
+            using HttpResponseMessage response = await _graphClient.SendAsync(request);
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.TooManyRequests:
+                    RetryConditionHeaderValue retryAfter = response.Headers.RetryAfter!;
+
+                    TimeSpan retryBuffer = retryAfter.Delta!.Value.Add(TimeSpan.FromSeconds(15));
+
+                    await Task.Delay(retryBuffer);
+                    break;
+                
+                default:
+                    content = await response.Content.ReadAsStringAsync();
+                    isFinished = true;
+                    break;
+            }
+        }
+
+        return content;
+    }
+}

--- a/src/Lib/Services/GraphClientService/graph-calls/GetUserAsync.cs
+++ b/src/Lib/Services/GraphClientService/graph-calls/GetUserAsync.cs
@@ -10,11 +10,15 @@ public partial class GraphClientService
     {
         string apiEndpoint = $"users/{userId}?$select={string.Join(",", _graphUserProps)}";
 
-        string? apiResultString = await _graphClient.SendApiCallAsync(
+        string? apiResultString = await SendApiCallAsync(
             endpoint: apiEndpoint,
-            apiPostBody: null,
             httpMethod: HttpMethod.Get
         );
+
+        if (apiResultString is null)
+        {
+            throw new Exception("API result string is null.");
+        }
 
         User user;
         try

--- a/src/Lib/Services/GraphClientService/graph-calls/GetUsersAsync.cs
+++ b/src/Lib/Services/GraphClientService/graph-calls/GetUsersAsync.cs
@@ -28,9 +28,8 @@ public partial class GraphClientService
             apiEndpoint ??= $"users?$select={string.Join(",", _graphUserProps)}&$filter={queryFilter}&$count=true";
 
             // Call the API to get the users.
-            string? apiResultString = await _graphClient.SendApiCallAsync(
+            string? apiResultString = await SendApiCallAsync(
                 endpoint: apiEndpoint!,
-                apiPostBody: null,
                 httpMethod: HttpMethod.Get
             );
 

--- a/src/Lib/Services/GraphClientService/graph-calls/SendEmailAsync.cs
+++ b/src/Lib/Services/GraphClientService/graph-calls/SendEmailAsync.cs
@@ -17,10 +17,10 @@ public partial class GraphClientService
         try
         {
             // Create a draft message.
-            string? draftResponse = await _graphClient.SendApiCallAsync(
+            string? draftResponse = await SendApiCallAsync(
                 endpoint: $"users/{sendAsUser}/messages",
-                apiPostBody: messageJson,
-                httpMethod: HttpMethod.Post
+                httpMethod: HttpMethod.Post,
+                body: messageJson
             );
 
             Message draftItem = JsonSerializer.Deserialize(
@@ -29,16 +29,14 @@ public partial class GraphClientService
             )!;
 
             // Send the draft message.
-            await _graphClient.SendApiCallAsync(
+            await SendApiCallAsync(
                 endpoint: $"users/{sendAsUser}/messages/{draftItem.Id!}/send",
-                apiPostBody: null,
                 httpMethod: HttpMethod.Post
             );
 
             // Delete the draft message.
-            await _graphClient.SendApiCallAsync(
+            await SendApiCallAsync(
                 endpoint: $"users/{sendAsUser}/messages/{draftItem.Id!}",
-                apiPostBody: null,
                 httpMethod: HttpMethod.Delete
             );
 

--- a/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
+++ b/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
@@ -1,5 +1,4 @@
-﻿using SmallsOnline.MsGraphClient.Models;
-using SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
+﻿using SmallsOnline.PasswordExpirationNotifier.Lib.Models.Graph;
 
 namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 
@@ -11,7 +10,7 @@ public interface IGraphClientService
     /// <summary>
     /// The underlying <see cref="SmallsOnline.MsGraphClient.Models.GraphClient"/> instance.
     /// </summary>
-    GraphClient GraphClient { get; }
+    HttpClient GraphClient { get; }
 
     /// <summary>
     /// Get user information from the Microsoft Graph API.

--- a/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
+++ b/src/Lib/Services/GraphClientService/interfaces/IGraphClientService.cs
@@ -8,7 +8,7 @@ namespace SmallsOnline.PasswordExpirationNotifier.Lib.Services;
 public interface IGraphClientService
 {
     /// <summary>
-    /// The underlying <see cref="SmallsOnline.MsGraphClient.Models.GraphClient"/> instance.
+    /// The underlying <see cref="HttpClient"/> for making the API calls.
     /// </summary>
     HttpClient GraphClient { get; }
 


### PR DESCRIPTION
I'm removing the dependency to my generic Microsoft Graph client library, [SmallsOnline.MsGraphClient](https://github.com/Smalls1652/SmallsOnline.MsGraphClient). It's now implemented internally.

This allows for:

- Quicker updates to [`Microsoft.Identity.Client`](https://www.nuget.org/packages/Microsoft.Identity.Client).
- Easier updates for new features and/or fixing bugs related to calling the Microsoft Graph API.