### PR TITLE
[Bug fix] Email serialization

### DIFF
--- a/src/Lib/Services/GraphClientService/graph-calls/SendEmailAsync.cs
+++ b/src/Lib/Services/GraphClientService/graph-calls/SendEmailAsync.cs
@@ -11,7 +11,7 @@ public partial class GraphClientService
         // Serialize the message to JSON.
         string messageJson = JsonSerializer.Serialize(
             value: message,
-            jsonTypeInfo: _jsonSourceGenerationContext.Message
+            jsonTypeInfo: JsonSourceGenerationContext.Default.Message
         );
 
         try
@@ -25,7 +25,7 @@ public partial class GraphClientService
 
             Message draftItem = JsonSerializer.Deserialize(
                 json: draftResponse!,
-                jsonTypeInfo: _jsonSourceGenerationContext.Message
+                jsonTypeInfo: JsonSourceGenerationContext.Default.Message
             )!;
 
             // Send the draft message.


### PR DESCRIPTION
This is a quick fix for sending emails through the Graph API failing.

It seems that initializing the source generated JSON context in a class, like done below in `GraphClientService.cs`, **does not include the options** defined for the `JsonSerializerContext`.

`.\src\Lib\JsonSourceGenerationContext.cs`:

```csharp
[JsonSourceGenerationOptions(
    WriteIndented = true,
    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
    GenerationMode = JsonSourceGenerationMode.Default,
    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
)]
[...]
internal partial class JsonSourceGenerationContext : JsonSerializerContext
{
}
```

`.\src\Lib\Services\GraphClientService\GraphClientService.cs`:

```csharp
private readonly JsonSourceGenerationContext _jsonSourceGenerationContext = new();
```

In `SendEmailAsync.cs`, specifying the `jsonTypeInfo` from `_jsonSourceGenerationContext` when serializing the type to a string would cause the generated JSON to not use the serialization options. Specifically the `JsonIgnoreCondition.WhenWritingNull` would not be utilized and null properties would appear in the JSON string. Whenever the JSON was sent to the Graph API, the Graph API would throw a `BadRequest` error because properties that **should not** be in the JSON were provided.

On my end, the way I have been using source generated JSON types did not change with the `v0.1.0` update. This is leading me to believe that something changed with .NET, but I can't find anything in recent updates that would cause that.

Either way, this fix will be expanded out to the rest of the project. The way I've been supplying the `jsonTypeInfo` parameter for `JsonSerializer.Serialize()` and `JsonSerializer.Deserialize()` isn't the _right_ way to do it, so I'll need to update the rest of the project to follow what I've done here.