### PR TITLE
[Bug fix] Missing attachments in email templates

### DIFF
--- a/src/Lib/Services/CosmosDBClientService/email-templates/GetEmailTemplateConfigsAsync.cs
+++ b/src/Lib/Services/CosmosDBClientService/email-templates/GetEmailTemplateConfigsAsync.cs
@@ -29,7 +29,7 @@ public partial class CosmosDbClientService
         EmailTemplateConfig[] configs = new EmailTemplateConfig[totalConfigCount];
 
         // Define the query to get the IDs of all configs.
-        QueryDefinition configsQuery = new("SELECT * FROM c");
+        QueryDefinition configsQuery = new("SELECT c.id, c.partitionKey FROM c");
 
         using FeedIterator feedIterator = container.GetItemQueryStreamIterator(
             queryDefinition: configsQuery,
@@ -51,7 +51,7 @@ public partial class CosmosDbClientService
 
             foreach (EmailTemplateConfig config in configsResponse!.Documents!)
             {
-                configs[i] = config;
+                configs[i] = await GetEmailTemplateConfigAsync(config.Id);
                 i++;
             }
         }


### PR DESCRIPTION
Whenever `GetEmailTemplateConfigsAsync()` was called, it would only get the template config and not the attachments in the config. This change basically gets the metadata for all of the templates and calls `GetEmailTemplateConfigAsync()` to get everything for each individual template.